### PR TITLE
Accept project-scoped AI Foundry endpoints

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -49,6 +49,11 @@ USER_SUMMARY_EVERY_N=20
 MEMORY_PROCESSOR_OWNER=
 
 # ---- AI Foundry / Azure OpenAI ----
+# Use the account-level inference endpoint. Both of these forms work:
+#   https://<your-account>.services.ai.azure.com
+#   https://<your-account>.openai.azure.com
+# A project-scoped Foundry URL (".../api/projects/<name>") is also accepted and
+# automatically normalized to the inference base.
 AI_FOUNDRY_ENDPOINT=https://<your-account>.openai.azure.com/
 AI_FOUNDRY_API_KEY=
 AI_FOUNDRY_EMBEDDING_DEPLOYMENT_NAME=text-embedding-3-large

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## Release History
 
+### Unreleased
+
+#### Other Changes
+* `ai_foundry_endpoint` now accepts a project-scoped Azure AI Foundry URL
+  (`https://<resource>.services.ai.azure.com/api/projects/<name>`) in addition
+  to the account-level inference endpoint. The project path is automatically
+  stripped to the inference base, so callers can paste whichever form the
+  Foundry portal shows them without hitting opaque 404s.
+
 ### 0.1.0b2 (2026-06-03)
 
 #### Bugs Fixed

--- a/azure/cosmos/agent_memory/_base/base_client.py
+++ b/azure/cosmos/agent_memory/_base/base_client.py
@@ -14,6 +14,7 @@ from azure.cosmos.agent_memory._utils import (
     _resolve_cosmos_provisioning_autoscale_max_ru,
     _resolve_cosmos_throughput_mode,
     _resolve_embedding_dimensions,
+    normalize_ai_foundry_endpoint,
 )
 from azure.cosmos.agent_memory.exceptions import CosmosNotConnectedError, MemoryNotFoundError, ValidationError
 from azure.cosmos.agent_memory.logging import configure_logging, get_logger
@@ -69,7 +70,7 @@ class _BaseMemoryClient:
             autoscale_max_ru=cosmos_autoscale_max_ru,
         )
 
-        self._ai_foundry_endpoint = ai_foundry_endpoint
+        self._ai_foundry_endpoint = normalize_ai_foundry_endpoint(ai_foundry_endpoint)
         self._ai_foundry_credential = ai_foundry_credential
         self._ai_foundry_api_key = ai_foundry_api_key
         self._embedding_deployment_name = embedding_deployment_name

--- a/azure/cosmos/agent_memory/_utils.py
+++ b/azure/cosmos/agent_memory/_utils.py
@@ -173,6 +173,41 @@ def _resolve_embedding_dimensions(val: Optional[int]) -> int:
     return parsed
 
 
+_AI_FOUNDRY_PROJECT_PATH_RE = re.compile(r"/api/projects/[^/]+/?.*$", re.IGNORECASE)
+
+
+def normalize_ai_foundry_endpoint(endpoint: Optional[str]) -> Optional[str]:
+    """Normalize an AI Foundry / Azure OpenAI endpoint to the inference base URL.
+
+    The toolkit reaches the model inference API through the OpenAI SDK
+    (``AzureOpenAI(azure_endpoint=...)``), which expects the account-level
+    inference endpoint, for example::
+
+        https://<resource>.services.ai.azure.com
+        https://<resource>.openai.azure.com
+
+    The Azure AI Foundry portal, however, commonly surfaces a *project*-scoped
+    endpoint of the form::
+
+        https://<resource>.services.ai.azure.com/api/projects/<project-name>
+
+    For ``*.services.ai.azure.com`` resources the project path lives on the same
+    host that serves inference, so this helper strips a trailing
+    ``/api/projects/<name>`` segment (plus any surrounding whitespace or trailing
+    slash) to recover the base inference endpoint. Callers can therefore paste
+    either form.
+
+    Endpoints that don't carry a project path are returned unchanged aside from
+    whitespace/trailing-slash trimming, so non-Foundry endpoints keep working.
+    ``None``/empty values are passed through untouched.
+    """
+    if not endpoint:
+        return endpoint
+    trimmed = endpoint.strip()
+    trimmed = _AI_FOUNDRY_PROJECT_PATH_RE.sub("", trimmed)
+    return trimmed.rstrip("/")
+
+
 _ALLOWED_EMBEDDING_DATA_TYPES = ("float32", "uint8", "int8")
 _ALLOWED_DISTANCE_FUNCTIONS = ("cosine", "dotproduct", "euclidean")
 

--- a/azure/cosmos/agent_memory/_utils.py
+++ b/azure/cosmos/agent_memory/_utils.py
@@ -12,6 +12,7 @@ import re
 import uuid
 from datetime import datetime, timezone
 from typing import Any, Optional
+from urllib.parse import urlsplit, urlunsplit
 
 from ._container_routing import USER_SCOPED_MEMORIES_TYPES
 from ._query_builder import _QueryBuilder
@@ -174,6 +175,7 @@ def _resolve_embedding_dimensions(val: Optional[int]) -> int:
 
 
 _AI_FOUNDRY_PROJECT_PATH_RE = re.compile(r"/api/projects/[^/]+/?.*$", re.IGNORECASE)
+_AI_FOUNDRY_HOST_SUFFIX = ".services.ai.azure.com"
 
 
 def normalize_ai_foundry_endpoint(endpoint: Optional[str]) -> Optional[str]:
@@ -197,14 +199,21 @@ def normalize_ai_foundry_endpoint(endpoint: Optional[str]) -> Optional[str]:
     slash) to recover the base inference endpoint. Callers can therefore paste
     either form.
 
-    Endpoints that don't carry a project path are returned unchanged aside from
-    whitespace/trailing-slash trimming, so non-Foundry endpoints keep working.
-    ``None``/empty values are passed through untouched.
+    The project-path stripping is applied **only** when the URL host ends with
+    ``.services.ai.azure.com``, and only to the path component, so unrelated
+    endpoints that happen to contain ``/api/projects/...`` in their path are left
+    untouched. Endpoints that don't carry a project path are returned unchanged
+    aside from whitespace/trailing-slash trimming, so non-Foundry endpoints keep
+    working. ``None``/empty values are passed through untouched.
     """
     if not endpoint:
         return endpoint
     trimmed = endpoint.strip()
-    trimmed = _AI_FOUNDRY_PROJECT_PATH_RE.sub("", trimmed)
+    parts = urlsplit(trimmed)
+    host = parts.hostname or ""
+    if host.lower().endswith(_AI_FOUNDRY_HOST_SUFFIX):
+        new_path = _AI_FOUNDRY_PROJECT_PATH_RE.sub("", parts.path)
+        trimmed = urlunsplit((parts.scheme, parts.netloc, new_path, parts.query, parts.fragment))
     return trimmed.rstrip("/")
 
 

--- a/tests/unit/_base/test_base_client.py
+++ b/tests/unit/_base/test_base_client.py
@@ -67,9 +67,7 @@ def test_base_config_validates_throughput_mode():
 
 
 def test_base_config_normalizes_ai_foundry_project_endpoint():
-    client = DummyClient(
-        ai_foundry_endpoint="https://my-res.services.ai.azure.com/api/projects/my-project"
-    )
+    client = DummyClient(ai_foundry_endpoint="https://my-res.services.ai.azure.com/api/projects/my-project")
     assert client._ai_foundry_endpoint == "https://my-res.services.ai.azure.com"
 
 

--- a/tests/unit/_base/test_base_client.py
+++ b/tests/unit/_base/test_base_client.py
@@ -66,6 +66,18 @@ def test_base_config_validates_throughput_mode():
         DummyClient(cosmos_throughput_mode="invalid")
 
 
+def test_base_config_normalizes_ai_foundry_project_endpoint():
+    client = DummyClient(
+        ai_foundry_endpoint="https://my-res.services.ai.azure.com/api/projects/my-project"
+    )
+    assert client._ai_foundry_endpoint == "https://my-res.services.ai.azure.com"
+
+
+def test_base_config_leaves_plain_ai_foundry_endpoint_untouched():
+    client = DummyClient(ai_foundry_endpoint="https://my-res.services.ai.azure.com")
+    assert client._ai_foundry_endpoint == "https://my-res.services.ai.azure.com"
+
+
 def test_require_cosmos_guard_and_context_manager():
     client = DummyClient()
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -290,3 +290,19 @@ def test_normalize_ai_foundry_endpoint_is_case_insensitive_on_project_path():
         normalize_ai_foundry_endpoint("https://my-res.services.ai.azure.com/API/Projects/my-project")
         == "https://my-res.services.ai.azure.com"
     )
+
+
+def test_normalize_ai_foundry_endpoint_leaves_non_foundry_host_with_project_path():
+    # A non-Foundry host that happens to carry /api/projects/ in its path must be
+    # left untouched (aside from trailing-slash trimming).
+    assert (
+        normalize_ai_foundry_endpoint("https://example.com/api/projects/my-project")
+        == "https://example.com/api/projects/my-project"
+    )
+
+
+def test_normalize_ai_foundry_endpoint_leaves_openai_host_with_project_path():
+    assert (
+        normalize_ai_foundry_endpoint("https://my-res.openai.azure.com/api/projects/my-project")
+        == "https://my-res.openai.azure.com/api/projects/my-project"
+    )

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -263,25 +263,19 @@ def test_normalize_ai_foundry_endpoint_strips_project_path_with_trailing_slash()
 
 def test_normalize_ai_foundry_endpoint_strips_project_path_with_extra_segments():
     assert (
-        normalize_ai_foundry_endpoint(
-            "https://my-res.services.ai.azure.com/api/projects/my-project/deployments/x"
-        )
+        normalize_ai_foundry_endpoint("https://my-res.services.ai.azure.com/api/projects/my-project/deployments/x")
         == "https://my-res.services.ai.azure.com"
     )
 
 
 def test_normalize_ai_foundry_endpoint_leaves_base_services_endpoint():
     assert (
-        normalize_ai_foundry_endpoint("https://my-res.services.ai.azure.com")
-        == "https://my-res.services.ai.azure.com"
+        normalize_ai_foundry_endpoint("https://my-res.services.ai.azure.com") == "https://my-res.services.ai.azure.com"
     )
 
 
 def test_normalize_ai_foundry_endpoint_leaves_openai_endpoint():
-    assert (
-        normalize_ai_foundry_endpoint("https://my-res.openai.azure.com")
-        == "https://my-res.openai.azure.com"
-    )
+    assert normalize_ai_foundry_endpoint("https://my-res.openai.azure.com") == "https://my-res.openai.azure.com"
 
 
 def test_normalize_ai_foundry_endpoint_trims_whitespace_and_trailing_slash():
@@ -296,4 +290,3 @@ def test_normalize_ai_foundry_endpoint_is_case_insensitive_on_project_path():
         normalize_ai_foundry_endpoint("https://my-res.services.ai.azure.com/API/Projects/my-project")
         == "https://my-res.services.ai.azure.com"
     )
-

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -10,6 +10,7 @@ from azure.cosmos.agent_memory._utils import (
     _resolve_embedding_data_type,
     _resolve_full_text_language,
     compute_content_hash,
+    normalize_ai_foundry_endpoint,
 )
 from azure.cosmos.agent_memory.exceptions import ConfigurationError, ValidationError
 
@@ -234,3 +235,65 @@ def test_resolve_full_text_language_defaults(monkeypatch):
 def test_resolve_full_text_language_from_env(monkeypatch):
     monkeypatch.setenv("COSMOS_DB_FULL_TEXT_LANGUAGE", "fr-FR")
     assert _resolve_full_text_language(None) == "fr-FR"
+
+
+# ---------------------------------------------------------------------------
+# normalize_ai_foundry_endpoint
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("value", [None, ""])
+def test_normalize_ai_foundry_endpoint_passes_through_empty(value):
+    assert normalize_ai_foundry_endpoint(value) == value
+
+
+def test_normalize_ai_foundry_endpoint_strips_project_path():
+    assert (
+        normalize_ai_foundry_endpoint("https://my-res.services.ai.azure.com/api/projects/my-project")
+        == "https://my-res.services.ai.azure.com"
+    )
+
+
+def test_normalize_ai_foundry_endpoint_strips_project_path_with_trailing_slash():
+    assert (
+        normalize_ai_foundry_endpoint("https://my-res.services.ai.azure.com/api/projects/my-project/")
+        == "https://my-res.services.ai.azure.com"
+    )
+
+
+def test_normalize_ai_foundry_endpoint_strips_project_path_with_extra_segments():
+    assert (
+        normalize_ai_foundry_endpoint(
+            "https://my-res.services.ai.azure.com/api/projects/my-project/deployments/x"
+        )
+        == "https://my-res.services.ai.azure.com"
+    )
+
+
+def test_normalize_ai_foundry_endpoint_leaves_base_services_endpoint():
+    assert (
+        normalize_ai_foundry_endpoint("https://my-res.services.ai.azure.com")
+        == "https://my-res.services.ai.azure.com"
+    )
+
+
+def test_normalize_ai_foundry_endpoint_leaves_openai_endpoint():
+    assert (
+        normalize_ai_foundry_endpoint("https://my-res.openai.azure.com")
+        == "https://my-res.openai.azure.com"
+    )
+
+
+def test_normalize_ai_foundry_endpoint_trims_whitespace_and_trailing_slash():
+    assert (
+        normalize_ai_foundry_endpoint("  https://my-res.services.ai.azure.com/  ")
+        == "https://my-res.services.ai.azure.com"
+    )
+
+
+def test_normalize_ai_foundry_endpoint_is_case_insensitive_on_project_path():
+    assert (
+        normalize_ai_foundry_endpoint("https://my-res.services.ai.azure.com/API/Projects/my-project")
+        == "https://my-res.services.ai.azure.com"
+    )
+


### PR DESCRIPTION
## Accept project-scoped AI Foundry endpoints

### Why

`ai_foundry_endpoint` only accepts the **account-level inference endpoint** today (`https://<resource>.services.ai.azure.com` or `.openai.azure.com`), because the toolkit talks to the model APIs through the OpenAI SDK (`AzureOpenAI(azure_endpoint=...)`). But the Azure AI Foundry portal commonly hands users a **project-scoped** URL instead:

```
https://<resource>.services.ai.azure.com/api/projects/<project-name>
```

Pasting that into `AI_FOUNDRY_ENDPOINT` yields opaque `404`/routing errors. The parameter name promises "a Foundry endpoint" but the implementation silently demands an Azure OpenAI one.

This surfaced while integrating the toolkit into the **Microsoft Agent Framework** as a `CosmosMemoryContextProvider` (new `agent-framework-azure-cosmos-memory` package). The goal there is a **single-endpoint experience**: one AI Foundry endpoint drives both the memory pipeline (this toolkit) and the chat agent (the framework's `FoundryChatClient`). The catch — the framework's client accepts the project URL natively, but the toolkit rejects the exact same value unless the user manually strips `/api/projects/<name>`.

### Why fix it here (and not in the Agent Framework integration)

`ai_foundry_endpoint` is the toolkit's own public contract, so the toolkit should own what's valid for it. Fixing it here benefits **every** consumer (direct users, the Agent Framework provider, future integrations), not just one wrapper. Pushing normalization into the integration layer would paper over the leaky abstraction and leave the next caller to rediscover the same papercut. Since, for `*.services.ai.azure.com` resources, the project path is just a suffix on the same host that serves inference, the safe, canonical fix lives right where the endpoint is consumed.

### What changed

- **New helper** `normalize_ai_foundry_endpoint()` in `_utils.py`: strips a
  trailing `/api/projects/<name>[/...]` (case-insensitive), trims whitespace and
  trailing slash, passes `None`/empty through, and leaves non-project endpoints
  unchanged.
- **Applied once** in `_BaseMemoryClient._init_base_config` — the single config
  chokepoint shared by the sync and async clients.
- **Docs**: `.env.template` documents the accepted forms; `CHANGELOG.md` updated.

### Behavior (non-breaking)

| Input | Result |
|-------|--------|
| `https://r.services.ai.azure.com/api/projects/p` | `https://r.services.ai.azure.com` |
| `https://r.services.ai.azure.com` / `https://r.openai.azure.com` | unchanged |
| `  https://r.services.ai.azure.com/  ` | `https://r.services.ai.azure.com` |
| `None` / `""` | unchanged |

### Tests

10 new tests (8 for the helper, 2 on the base client). Full unit suite green except 5 pre-existing `duration_ms > 0.0` reconcile-telemetry timing flakes (confirmed failing on `main`; unrelated).

### Scope

Covers the modern `*.services.ai.azure.com` case via pure string normalization (no new deps). Legacy hub/project endpoints on a *different* host than the linked Azure OpenAI resource would need `AIProjectClient` lookup — left as a follow-up.